### PR TITLE
Bugfix: IFS-3727 Check both snapshot and rc version, check release existence for tags

### DIFF
--- a/.github/workflows/maven_deploy_template.yml
+++ b/.github/workflows/maven_deploy_template.yml
@@ -119,7 +119,7 @@ jobs:
             exit 1
           fi
       - name: Check release existence
-        if: github.ref_type != 'tag'
+        if: github.ref_type == 'tag'
         env:
           DEPLOY_SERVER_USERNAME: ${{ secrets.DEPLOY_SERVER_USER_NAME }}
           DEPLOY_SERVER_TOKEN: ${{ secrets.DEPLOY_SERVER_TOKEN }}

--- a/.github/workflows/maven_deploy_template.yml
+++ b/.github/workflows/maven_deploy_template.yml
@@ -26,6 +26,10 @@ on:
         type: string
         description: 'Reference to deployment repository'
         default: 'repository'
+      deploy-server-url:
+        required: false
+        type: string
+        description: 'Deployment repository URL'
       deploy-url-release:
         required: false
         type: string

--- a/.github/workflows/maven_deploy_template.yml
+++ b/.github/workflows/maven_deploy_template.yml
@@ -110,10 +110,11 @@ jobs:
             echo "ERROR: given version with value ${{ inputs.version }} does not correspond to build version $PROJECT_VERSION"
             exit 1
           fi
-      - name: Check for snapshot version
+      - name: Check for snapshot or RC version
         if: github.ref_type != 'tag'
         run: |
-          if [[ ! "${{ steps.getVersion.outputs.project-version }}" =~ "-SNAPSHOT" ]]; then
+          if [[ ! "${{ steps.getVersion.outputs.project-version }}" =~ "-SNAPSHOT" 
+          && ! "${{ steps.getVersion.outputs.project-version }}" =~ "-RC-" ]]; then
             echo "ERROR: Trying to deploy untagged version as stable release"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+# v1.3.0
+- `IFS-3727`: Überprüfung von Snapshot als auch RC-Versionen, Überprüfung von Release-Existenz für Tags in `maven_deploy_template.yml`
+
 # v1.2.0
 - `IFS-3767`: Hinzufügen des `OSS Review Toolkit` als Template
 
 # v1.1.0 
-- `IFS-3729`: Hinzufügen von `severity-threshold` und `perform-scan` als Inputs zu `maven_dependency_scan.template`
-- `IFS-3826`: Hinzufügen von `environment` zur Nutzung von GitHub Environments mit `maven-deploy-template`
+- `IFS-3729`: Hinzufügen von `severity-threshold` und `perform-scan` als Inputs zu `maven_dependency_scan_template.yml`
+- `IFS-3826`: Hinzufügen von `environment` zur Nutzung von GitHub Environments mit `maven_deploy_template.yml`
 
 # v1.0.0
 - `IFS-2835`: Aktualisierung der `dependency_review_template.yml` zur Überprüfung der Lizenzgültigkeit


### PR DESCRIPTION
**Cause:**
In `maven_deploy_template.yml`, the `Validate` job, specifically the step `Check for snapshot version` failed ([isy-sonderzeichen](https://github.com/IsyFact/isy-sonderzeichen/actions/runs/10037340783/job/27736999849)), as it didn’t check for RC version. The `Check release existence job` must also be run with tag, not non-tag versions like snapshot or RC as they are not uploaded to the remote Maven repository, but GitHub Packages.

**Fix:** 
- Check both snapshot and RC version
- Check release existence for tags